### PR TITLE
chatspaceインクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,116 @@
+$(function() {
+  // 文字が1文字以上の時に発火するHTML
+  function addUser(user) {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">${user.name}</p>
+        <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+      </div>
+    `;
+    // 入力内容をjsとして変換?
+    // チャットメンバーの下に検索結果が表示されるのでセレクタはuser-search-resultにする
+    $("#user-search-result").append(html);
+    
+  }
+
+  // 文字が0文字の時に発火するHTML
+  function addNoUser() {
+    let html = `
+      <div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">ユーザーが見つかりません</p>
+      </div>
+    `;
+    // 入力内容をjsとして変換?
+    // チャットメンバーの下に検索結果が表示されるのでセレクタはuser-search-resultにする
+    $("#user-search-result").append(html);
+  }
+
+  // addDeleteUserの定義
+  function addDeleteUser(name, id) {
+    let html = `
+    <div class="chat-group-user clearfix" id="${id}">
+    
+      <p class="chat-group-user__name">${name}</p>
+      <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn" data-user-id="${id}" data-user-name="${name}">削除</div>
+    </div>`;
+    $(".js-add-user").append(html);
+  }
+  // addmemberの定義
+  // ユーザidをコントローラー側にパラメーターとして送る記述
+  function addMember(userId) {
+    let html = `<input value="${userId}" name="group[user_ids][]" type="hidden" id="group_user_ids_${userId}" />`;
+    $(`#${userId}`).append(html);
+  }
+
+
+  // 1文字打つたびに内容が表示される
+  // チャットメンバーの下に検索結果が表示されるのでセレクタはuser-search-resultにする
+  $("#user-search-field").on("keyup", function() {
+    
+    // チャットメンバーに入力した内容を取得
+    let input = $("#user-search-field").val();
+   
+    // users_controller.rbに送信する内容を設定
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+    // 非同期通信成功時
+      // index.json.jbuilderのデータをusersで受け取る
+      .done(function(users) {
+        
+        // チャットメンバーの入力後の中身を空にする
+        // チャットメンバーの下に検索結果が表示されるのでセレクタはuser-search-resultにする
+        $("#user-search-result").empty();
+        // 入力する文字数が1文字以上の時
+        if (users.length !== 0) {
+          users.forEach(function(user) {
+            // addUser(user);を発火
+            addUser(user);
+          });
+          // 入力した文字が0文字の場合
+        } else if (input.length == 0) {
+          return false;
+        } else {
+          // addNoUser();を発火
+          addNoUser();
+        }
+          
+      })
+      // 非同期通信失敗
+      .fail(function() {
+        alert("通信エラーです。ユーザーが表示できません。");
+      });
+  });
+  // 追加ボタンを押した際の処理
+  // $(document).onでhtmlの情報を取得(appendさせた情報を取得)
+  // .chat-group-user__btn--add(追記ボタン)を押すと88行目以降が発火
+  $(document).on("click", ".chat-group-user__btn--add", function() {
+  
+    // 追加ボタンの対象のユーザー情報を変数userNameに代入
+    //  メンバーを追加に入力した内容をattrの内容を取得して変数に代入
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+
+    $(this)
+    // .parent()を使うことでthisの親要素chat-group-user clearfixを取得
+     
+      .parent()
+      // 検索結果からremoveメソッドを使い内容(chat-group-user clearfix)を削除
+      .remove();
+
+    // メンバーの追加(function addDeleteUser(name, id) の呼び出し)
+    addDeleteUser(userName, userId);
+    // メンバーの追加(function addMember(userId)の呼び出し)
+    addMember(userId);
+
+  });
+  // チャットメンバーに追加したメンバーを削除する
+  $(document).on("click", ".chat-group-user__btn--remove", function() {
+    $(this)
+      .parent()
+      .remove();
+  });
+});

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,6 +34,7 @@ class GroupsController < ApplicationController
   private
 
   def group_params
+   
     params.require(:group).permit(:name, user_ids: [] )
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,20 @@ class UsersController < ApplicationController
     end
   end
 
+  def index
+    # user.jsで受け取った[:keyword] の内容で条件分岐
+    # [:keyword] の中身がない時
+    return nil if params[:keyword] == ""
+    # [:keyword] の中身がある時。LIKEを使ったあいまい検索
+  @users = User.where(['name LIKE(?)', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+
+  respond_to do |format|
+    format.html
+    format.json
+    end
+  end
+  
+
   private
 
   def user_params

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,3 +1,59 @@
+-# = form_for group do |f|
+-#   - if group.errors.any?
+-#     .chat-group-form__errors
+-#       %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+-#       %ul
+-#         - group.errors.full_messages.each do |message|
+-#           %li= message
+-#   .chat-group-form__field
+-#     .chat-group-form__field--left
+-#       = f.label :name, class: 'chat-group-form__label'  
+-#     .chat-group-form__field--right
+-#       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+
+-#   .chat-group-form__field.clearfix
+-#     .chat-group-form__field--left
+-#       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+-#     .chat-group-form__field--right
+
+-#     -# インクリメンタルサーチ後の新規追加項目
+-#       #chat-group-users.js-add-user
+-#           .chat-group-user.clearfix.js-chat-member
+-#             %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+-#             %p.chat-group-user__name= current_user.name
+
+-#           - group.users.each do |user|
+-#             - if current_user.name != user.name
+-#               .chat-group-user.clearfix.js-chat-member
+-#                 %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+-#                 %p.chat-group-user__name
+-#                   = user.name 
+-#                 %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+-#                   削除
+
+
+-#       -# csインクリメンタルサーチ追加項目(2.テキストフィールドを作成する)
+-#       .chat-group-form__search.clearfix
+-#         %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+-#       #user-search-result
+
+-#       -# #chat-group-users.js-add-user
+
+-#   .chat-group-form__field.clearfix
+-#     .chat-group-form__field--left
+-#       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+-#     .chat-group-form__field--right
+-#       -# csインクリメンタルサーチ追加項目(2.テキストフィールドを作成する)
+-#       #chat-group-users.js-add-user
+-#       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+-#   -#     = f.collection_check_boxes :user_ids, User.all, :id, :name
+-#   -#     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+-#   .chat-group-form__field.clearfix
+-#     .chat-group-form__field--left
+-#     .chat-group-form__field--right
+-#       = f.submit class: 'chat-group-form__action-btn'
+
+
 = form_for group do |f|
   - if group.errors.any?
     .chat-group-form__errors
@@ -11,14 +67,34 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
+      -# 現在ログインしているユーザーはそのままチャットメンバーの中に残す
+      #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+
+        -# グループに登録したメンバーをチャットメンバーに追加するフォーム
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name 
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id  user.id
+  json.name  user.name
+end


### PR DESCRIPTION
#what
chatspaceにて新規チャットグループのチャットメンバー追加の部分に対してインクリメンタルサーチを実装。またインクリメンタルサーチをした際に表示されたメンバーを追加および削除できるように実装した。
#why
インクリメンタルサーチを実装することでチャットメンバーの追加をしやすくするため。
また追加と削除は重要な機能ため。