### PR TITLE
chatspace自動更新機能

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,5 @@
 $(function(){
   function buildHTML(message){
-   
     // カリキュラムに乗っている条件分岐はimageの有無の内容を大きく条件分岐したもの
     // 上記の理由からimageを司る表記をif文で条件分岐して変数に入れてからその変数を使って画像の表記をする
     // 上が画像ありの表記で下が画像なしの表記
@@ -12,13 +11,11 @@ $(function(){
 
     // 上記の条件文を三項演算子を利用した場合
      var image = message.image ? `<img src= "${message.image}" >`: ""
-    
-     
-
-    
+    // dat-idが反映されるようにしている
+    //  if (message.content && message.image) {
       // shift + @の記法でクォーテーションをつけるのを忘れずに
       // 上からメッセージ名前の要素、 投降日の要素、投降内容の要素、投降画像の要素
-      var html = `<div class="contents">
+      var html = `<div class="contents" data-message-id=${message.id}>
       <div class="contents__name">
       ${message.nickname}
       </div>
@@ -36,18 +33,12 @@ $(function(){
 
       </div>
       </div>`
+      
 
       return html;
-                }
+  }
     
-
-                
-                
-
-    
-    
-
-    // class =new_messageのsubmit(sendボタン)を実装
+     // class =new_messageのsubmit(sendボタン)を実装
   $('#new_message').on('submit',function(e){
     
     // htmlの機能の無効化
@@ -89,6 +80,58 @@ $(function(){
       // 非同期通信失敗時
     .fail(function(){
         alert("メッセージ送信に失敗しました");
+
     });
   });
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    //  div要素contentsか最新(last())のメッセージを取得して、さらにその中からmessage-idを取得
+    last_message_id = $('.contents').last().data('message-id')
+    // groupのidを取得するためにdiv要素.header__left__groupからgroup-idの要素を取得
+    group_id = $('.header__left__group').last().data('group-id')
+    
+  
+   
+   
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+
+      url: `/groups/${group_id}/api/messages`,
+      
+
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      // 追加するhtmlの入れ物を作る
+      
+      var insertHTML = '';
+      //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      //メッセージが入ったHTMLに、入れ物ごと追加
+      $('.main_contents').append(insertHTML);
+      $('.main_contents').animate({ scrollTop: $('.main_contents')[0].scrollHeight});
+    })
+
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
+    
+  }; 
+ 
+    // setIntervalのエラーが出ないように対策
+    // チャットのグループ以外ではfailの時のアラートが出ないようにする
+    group_id = $('.header__left__group').last().data('group-id')
+  if(location.pathname == `/groups/${group_id}/messages`){
+    // 7秒ごとにリクエストをするように実装
+  setInterval(reloadMessages, 7000);
+ }
+  
+
 });

--- a/app/assets/stylesheets/_side_contents.scss
+++ b/app/assets/stylesheets/_side_contents.scss
@@ -38,6 +38,12 @@
     .group {
       box-sizing: border-box;
       padding: 20px 0 40px;
+
+      a {
+        color: white;
+        text-decoration: none;
+      }
+
       &__name {
         font-size: 15px;
       }

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,14 @@
+# ::(名前空間 = namespace)を使うことでrubyのクラス名は装飾できる
+# 同様のクラス名で名付けたクラスを作っても区別できる
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id >  #{last_message_id}")
+    
+  end
+end
+

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y/%-m/%-d %-H:%M")
+  json.nickname message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,6 +1,6 @@
 .header
   .header__left
-    .header__left__group
+    .header__left__group{data: {group_id: @group.id}}
       = @group.name
     .header__left__member
       member:

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,6 @@
-.contents
+-# カスタムデータ属性を追加
+-# {}の数だけ-が追加される。
+.contents{data: {message_id: message.id}}
   .contents__name
     = message.user.name
   .contents__date

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -9,3 +9,7 @@ json.created_at @message.created_at.strftime("%Y/%-m/%-d %-H:%M")
 
 # messageとusersはアソシエーションを組んでいるのでusersテーブルのnameカラムを取り出すことができる
 json.nickname @message.user.name
+
+# 自動更新をする時に使うもの
+# app/views/api/messages/index.json.jbuilderだとリロードをした時にしか取得ができないので非同期通信の際にも反映されるように以下を記述
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,19 @@ Rails.application.routes.draw do
   root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :messages, only: [:index, :create]
+  resources :messages, only: [:index, :create]
+
+    # namespaceを利用したコントローラーのルーティング設定
+    namespace :api do
+      # defaultsオプションを使うことでレスポンスの形式をjsonにしている
+      resources :messages, only: :index, defaults: { format: 'json'}
+    end
   end
 end
 
-# localhost3000に接続した時にmessege#indexに接続。カリキュラムの支持からgroups#indexに記述を変更
-# usersコントローラーはeditとupdateアクションをするように指示
-# groupsコントローラーはnew,create,edit,updateアクションをするように指示
+# devise_for :users~resorces :messagesまでのコメントアウト
+  # localhost3000に接続した時にmessege#indexに接続。カリキュラムの支持からgroups#indexに記述を変更
+  # usersコントローラーはeditとupdateアクションをするように指示
+  # groupsコントローラーはnew,create,edit,updateアクションをするように指示
 
 


### PR DESCRIPTION
#what
chatspaceに自動更新機能を追加した
自動更新機能を追加することでリロードをすることなく新規メッセージを取得することができる。自動更新機能を追加するに際には新たにルーティング、コントローラー、jbuilderを追加し対応するアクションなどを追加した。
#why
自動更新機能はchatspaceでのコミュニケーションを円滑に進めるために必要な機能のため。