### PR TITLE
chatspaceのメッセージアラートの修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -128,6 +128,8 @@ $(function(){
  
    
   }
+
+  
    // 7秒ごとにリクエストをするように実装
   setInterval(reloadMessages, 7000);
   


### PR DESCRIPTION
#what
メッセージの送信をした際にメッセージを送信したにも関わらず"メッセージの送信に失敗しました"というアラートが表示されるため修正した。具体的には条件分岐を使いメッセージの送信画面でメッセージの送信に失敗をした時にはアラートが出るようにした。それ以外は出ないようにした。
#why
chatspaceを使うにあたり挙動としておかしいから